### PR TITLE
RSpec.describe usage

### DIFF
--- a/spec/lib/rest_api_template/controllers/health_check_controller_spec.rb
+++ b/spec/lib/rest_api_template/controllers/health_check_controller_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../../spec_helper"
 
-describe IPPoolsAPI::Controllers::HealthCheckController do
+RSpec.describe IPPoolsAPI::Controllers::HealthCheckController do
   include Rack::Test::Methods
 
   let (:status_route) { return "/status"}

--- a/spec/lib/rest_api_template/controllers/model1_controller_spec.rb
+++ b/spec/lib/rest_api_template/controllers/model1_controller_spec.rb
@@ -1,6 +1,6 @@
 require_relative "../../../spec_helper"
 
-describe IPPoolsAPI::Controllers::Model1Controller do
+RSpec.describe IPPoolsAPI::Controllers::Model1Controller do
   include Rack::Test::Methods
 
   before(:all) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,6 +17,10 @@ RSpec.configure do |config|
   temp_database_url = ENV['DATABASE_URL'].sub(conn.spec.config[:database], db_name)
   conn.disconnect!
 
+  # Disable usage of monkey patch version of describe
+  # by preventing global injection of RSpec's DSL
+  config.expose_dsl_globally = false
+
   config.before(:suite) do
     ActiveRecord::Base.establish_connection(temp_database_url)
     ActiveRecord::Migrator.migrate('db/migrate')


### PR DESCRIPTION
In an effort to enforce the use of non-monkey patch version of describe, we should always generate new APIs with DSL global injection off.